### PR TITLE
Release/1.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use TINTOlib, please cite the SoftwareX article below."
 title: "TINTOlib"
-version: "1.1.0"
-date-released: "2026-02-03"
+version: "1.3.0"
+date-released: "2026-07-31"
 license: "Apache-2.0"
 type: software
 repository-code: "https://github.com/oeg-upm/TINTOlib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "TINTOlib"
-version = "1.1.0"
+version = "1.3.0"
 authors = [
     { name="BorjaRei", email="borjareinoso@gmail.com" },
     { name= "manwestc", email="jcastillo@fi.upm.es"},
@@ -62,3 +62,11 @@ all = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["TINTOlib"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/TINTOlib",
+    "/LICENSE",
+    "/README.md",
+    "/pyproject.toml",
+]


### PR DESCRIPTION
## Summary

Prepare the TINTOlib 1.3.0 release after merging PRs #25 and #26.

## Changes

- Update the package version to `1.3.0`.
- Update the release date and citation metadata.
- Add the official project, documentation, benchmark, repository and issue URLs to the package metadata.
- Configure the source distribution to include only the package and required release files.

## Validation

- Wheel and source distribution built successfully.
- Both artifacts passed `twine check`.
- Wheel metadata reports version `1.3.0` and Python `>=3.9`.
- The wheel contains no caches, generated images, datasets or test results.
- The built wheel was installed in an isolated environment.
- All 12 image-generation methods completed successfully.

After merging this PR, the distributions will be rebuilt from `main` and published to PyPI as TINTOlib `1.3.0`.